### PR TITLE
fix: make cache_date timezone-aware when tzinfo is missing

### DIFF
--- a/src/carconnectivity_connectors/seatcupra/connector.py
+++ b/src/carconnectivity_connectors/seatcupra/connector.py
@@ -1330,6 +1330,8 @@ class Connector(BaseConnector):
                         img = base64.b64decode(img)  # pyright: ignore[reportPossiblyUnboundVariable]
                         img = Image.open(io.BytesIO(img))  # pyright: ignore[reportPossiblyUnboundVariable]
                         cache_date = datetime.fromisoformat(cache_date_string)
+                        if cache_date.tzinfo is None:
+                            cache_date = cache_date.replace(tzinfo=timezone.utc)
                     if img is None or self.active_config['max_age_static'] is None \
                             or (cache_date is not None and cache_date < (datetime.now(tz=timezone.utc) - timedelta(seconds=self.active_config['max_age_static']))):
                         try:
@@ -1450,6 +1452,8 @@ class Connector(BaseConnector):
         if not no_cache and (self.active_config['max_age'] is not None and session.cache is not None and url in session.cache):
             data, cache_date_string = session.cache[url]
             cache_date = datetime.fromisoformat(cache_date_string)
+            if cache_date.tzinfo is None:
+                cache_date = cache_date.replace(tzinfo=timezone.utc)
         if data is None or self.active_config['max_age'] is None \
                 or (cache_date is not None and cache_date < (datetime.now(tz=timezone.utc) - timedelta(seconds=self.active_config['max_age']))):
             try:


### PR DESCRIPTION
Ensure cache_date parsed from ISO format string is timezone-aware by assigning UTC when tzinfo is None, preventing comparison errors with timezone-aware datetime.now(tz=timezone.utc).

```
2026-03-23T20:23:45+0100:carconnectivity.connectors.seatcupra:CRITICAL:connector:Critical error during update: Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 200, in _background_loop
    self.fetch_all()
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 288, in fetch_all
    self.fetch_vehicles()
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 353, in fetch_vehicles
    data: Dict[str, Any] | None = self._fetch_data(url, session=self.session)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 1454, in _fetch_data
    or (cache_date is not None and cache_date < (datetime.now(tz=timezone.utc) - timedelta(seconds=self.active_config['max_age']))):
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
Exception in thread carconnectivity.connectors.seatcupra-background:
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 235, in _background_loop
    raise err
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 200, in _background_loop
    self.fetch_all()
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 288, in fetch_all
    self.fetch_vehicles()
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 353, in fetch_vehicles
    data: Dict[str, Any] | None = self._fetch_data(url, session=self.session)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/carconnectivity_connectors/seatcupra/connector.py", line 1454, in _fetch_data
    or (cache_date is not None and cache_date < (datetime.now(tz=timezone.utc) - timedelta(seconds=self.active_config['max_age']))):
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```